### PR TITLE
Refit react flow when sidebar is toggled

### DIFF
--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,15 +1,35 @@
 "use client";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Box from "@mui/material/Box";
 import NavSidebar from "@/components/nav/NavSidebar";
+import { SidebarContext } from "@/context/sidebar-context";
+
+const SIDEBAR_COLLAPSE_KEY = "koreo-sidebar-collapsed";
 
 export default function Template({ children }: { children: React.ReactNode }) {
+  const [isCollapsed, setIsCollapsed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(SIDEBAR_COLLAPSE_KEY);
+    setIsCollapsed(stored === "true");
+  }, []);
+
+  const toggleSidebar = () => {
+    setIsCollapsed((prev) => {
+      const newVal = !prev;
+      sessionStorage.setItem(SIDEBAR_COLLAPSE_KEY, newVal.toString());
+      return newVal;
+    });
+  };
+
   return (
-    <Box sx={{ display: "flex", height: "100%", weight: "100%" }}>
-      <NavSidebar />
-      <div className="providerflow">
-        <div className="reactflow-wrapper">{children}</div>
-      </div>
-    </Box>
+    <SidebarContext.Provider value={{ isCollapsed, toggleSidebar }}>
+      <Box sx={{ display: "flex", height: "100%", width: "100%" }}>
+        <NavSidebar isCollapsed={isCollapsed} toggleSidebar={toggleSidebar} />
+        <div className="providerflow">
+          <div className="reactflow-wrapper">{children}</div>
+        </div>
+      </Box>
+    </SidebarContext.Provider>
   );
 }

--- a/components/GraphDiagram.tsx
+++ b/components/GraphDiagram.tsx
@@ -271,7 +271,7 @@ const GraphDiagram: React.FC<React.PropsWithChildren<GraphDiagramProps>> = ({
     setSelectedEdge(null);
   }, [setSelectedEdge]);
 
-  // Re-fit the view after sidebar expands/collapses
+  // Re-fit the view after sidebar expands/collapses or graphEndpoint changes
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (reactFlowInstanceRef.current) {

--- a/components/GraphDiagram.tsx
+++ b/components/GraphDiagram.tsx
@@ -279,7 +279,7 @@ const GraphDiagram: React.FC<React.PropsWithChildren<GraphDiagramProps>> = ({
       }
     }, 0);
     return () => clearTimeout(timeout);
-  }, [isCollapsed]);
+  }, [isCollapsed, graphEndpoint]);
 
   return isLoading ? (
     <SkeletonFlow reactFlowInstanceRef={reactFlowInstanceRef} />

--- a/components/GraphDiagram.tsx
+++ b/components/GraphDiagram.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useCallback, useMemo } from "react";
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
 import { DefaultEdgeArrowOptions, NodeTypes } from "@/lib/diagrams";
 import {
   ReactFlow,
@@ -10,6 +16,7 @@ import {
   Edge,
   MiniMap,
   getOutgoers,
+  ReactFlowInstance,
 } from "@xyflow/react";
 import { getLayoutedElements } from "@/lib/dagre";
 import "@xyflow/react/dist/style.css";
@@ -17,6 +24,7 @@ import "@xyflow/react/dist/base.css";
 import useSWR from "swr";
 import SkeletonFlow from "@/components/SkeletonFlow";
 import { KoreoNode } from "@/components/CustomNode";
+import { useSidebar } from "@/context/sidebar-context";
 
 const MINI_MAP_NODE_THRESHOLD = 10;
 
@@ -39,6 +47,8 @@ const GraphDiagram: React.FC<React.PropsWithChildren<GraphDiagramProps>> = ({
   documentTitle,
   children,
 }) => {
+  const { isCollapsed } = useSidebar();
+  const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [initialized, setInitialized] = useState(false);
@@ -261,11 +271,25 @@ const GraphDiagram: React.FC<React.PropsWithChildren<GraphDiagramProps>> = ({
     setSelectedEdge(null);
   }, [setSelectedEdge]);
 
+  // Re-fit the view after sidebar expands/collapses
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (reactFlowInstanceRef.current) {
+        reactFlowInstanceRef.current.fitView();
+      }
+    }, 0);
+    return () => clearTimeout(timeout);
+  }, [isCollapsed]);
+
   return isLoading ? (
-    <SkeletonFlow />
+    <SkeletonFlow reactFlowInstanceRef={reactFlowInstanceRef} />
   ) : (
     <div style={{ height: "100%", width: "100%" }}>
       <ReactFlow
+        onInit={(instance) => {
+          reactFlowInstanceRef.current = instance;
+          instance.fitView();
+        }}
         nodes={visibleNodes}
         edges={visibleEdges}
         onNodesChange={onNodesChange}

--- a/components/SkeletonFlow.tsx
+++ b/components/SkeletonFlow.tsx
@@ -1,10 +1,12 @@
 "use client";
+import { MutableRefObject } from "react";
 import {
   ReactFlow,
   Edge,
   Node,
   useEdgesState,
   useNodesState,
+  ReactFlowInstance,
 } from "@xyflow/react";
 
 import { DefaultEdgeArrowOptions, NodeTypes } from "@/lib/diagrams";
@@ -84,7 +86,13 @@ const skeletonData: { nodes: Node[]; edges: Edge[] } = {
   ],
 };
 
-export default function SkeletonFlow() {
+type SkeletonFlowProps = {
+  reactFlowInstanceRef: MutableRefObject<ReactFlowInstance | null>;
+};
+
+const SkeletonFlow: React.FC<React.PropsWithChildren<SkeletonFlowProps>> = ({
+  reactFlowInstanceRef,
+}) => {
   const { nodes: skeletonNodes, edges: skeletonEdges } =
     getLayoutedElements(skeletonData);
   const [nodes, setNodes, onNodesChange] = useNodesState([...skeletonNodes]);
@@ -92,6 +100,10 @@ export default function SkeletonFlow() {
 
   return (
     <ReactFlow
+      onInit={(instance) => {
+        reactFlowInstanceRef.current = instance;
+        instance.fitView();
+      }}
       nodes={nodes}
       edges={edges}
       onNodesChange={onNodesChange}
@@ -104,4 +116,6 @@ export default function SkeletonFlow() {
       fitView
     />
   );
-}
+};
+
+export default SkeletonFlow;

--- a/components/nav/NavSidebar.tsx
+++ b/components/nav/NavSidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Box, Drawer, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import Menu from "@/components/nav/Menu";
@@ -22,26 +21,15 @@ const SidebarHeader = styled(Box)(({ theme }) => ({
   gap: theme.spacing(1),
 }));
 
-const SIDEBAR_COLLAPSE_KEY = "koreo-sidebar-collapsed";
+type NavSidebarProps = {
+  isCollapsed: boolean | null;
+  toggleSidebar: () => void;
+};
 
-export default function NavSidebar() {
-  const [isCollapsed, setIsCollapsed] = useState<boolean | null>(null);
-
-  // Load collapse state from sessionStorage on first render
-  useEffect(() => {
-    const stored = sessionStorage.getItem(SIDEBAR_COLLAPSE_KEY);
-    setIsCollapsed(stored === "true");
-  }, []);
-
-  // Update sessionStorage when collapse state changes
-  const toggleSidebar = () => {
-    setIsCollapsed((prev) => {
-      const newVal = !prev;
-      sessionStorage.setItem(SIDEBAR_COLLAPSE_KEY, newVal.toString());
-      return newVal;
-    });
-  };
-
+const NavSidebar: React.FC<React.PropsWithChildren<NavSidebarProps>> = ({
+  isCollapsed,
+  toggleSidebar,
+}) => {
   const expandedWidth = 300;
   const collapsedWidth = 64;
 
@@ -144,4 +132,6 @@ export default function NavSidebar() {
       )}
     </Drawer>
   );
-}
+};
+
+export default NavSidebar;

--- a/context/sidebar-context.tsx
+++ b/context/sidebar-context.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+type SidebarContextType = {
+  isCollapsed: boolean | null;
+  toggleSidebar: () => void;
+};
+
+export const SidebarContext = createContext<SidebarContextType | undefined>(
+  undefined,
+);
+
+export const useSidebar = () => {
+  const context = useContext(SidebarContext);
+  if (!context)
+    throw new Error("useSidebar must be used within SidebarProvider");
+  return context;
+};


### PR DESCRIPTION
Ensure the react flow graph view is refit when the sidebar is expanded/collapsed so that the graph is correctly centered based on the viewport size.